### PR TITLE
Fix hangup

### DIFF
--- a/lib/static_thread_pool.cpp
+++ b/lib/static_thread_pool.cpp
@@ -64,9 +64,12 @@ namespace cppcoro
 			return false;
 		}
 
-		void notify_intent_to_sleep() noexcept
+		// The return value will be true if the notification was successful, i.e.,
+		// if the thread was not yet marked to be asleep.
+		bool notify_intent_to_sleep() noexcept
 		{
-			m_isSleeping.store(true, std::memory_order_relaxed);
+			bool wasSleeping = m_isSleeping.exchange(true, std::memory_order_seq_cst);
+			return !wasSleeping;
 		}
 
 		void sleep_until_woken() noexcept
@@ -598,11 +601,13 @@ namespace cppcoro
 	void static_thread_pool::notify_intent_to_sleep(std::uint32_t threadIndex) noexcept
 	{
 		// First mark the thread as asleep
-		m_threadStates[threadIndex].notify_intent_to_sleep();
-
-		// Then publish the fact that a thread is asleep by incrementing the count
-		// of threads that are asleep.
-		m_sleepingThreadCount.fetch_add(1, std::memory_order_seq_cst);
+		if (m_threadStates[threadIndex].notify_intent_to_sleep())
+		{
+			// If the thread was not yet marked before to be asleep,
+			// then publish the fact that the thread is now asleep by incrementing the count
+			// of threads that are asleep.
+			m_sleepingThreadCount.fetch_add(1, std::memory_order_seq_cst);
+		}
 	}
 
 	void static_thread_pool::try_clear_intent_to_sleep(std::uint32_t threadIndex) noexcept


### PR DESCRIPTION
My test application sometimes ends up in a kind of hangup.
This happens quite often with clang-14 release builds, seldomly with gcc-10
release builds, not with debug builds.

The hangup is a kind of busy-waiting state where two threads from a static
thread pool are continually trying to wake each other, but not really
succeeding because both are already awake. A third thread, that could
allow the application to proceed, doesn't get the chance to continue.

The cause seems to be that m_sleepingThreadCount is not reflecting the
number of sleeping threads after a notify_intent_to_sleep() call where
m_isSleeping was already set. This probably can happen due to a spurious
wake-up (see comment above the try_clear_intent_to_sleep() call).

The proposed solution ensures that m_sleepingThreadCount is not increased
in such a situation.